### PR TITLE
Fixed Get Scheme button styles to prevent line-break.

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -235,6 +235,7 @@ body {
 #get-scheme-button {
 	width: 116px;
 	border: 1px solid #ccc;
+	white-space: nowrap;
 	
 	span {
 		font-size: 20px;


### PR DESCRIPTION
Hey @ciembor 

I've noticed a little styles issue and can't take it :)
![line-break](https://cloud.githubusercontent.com/assets/8465117/21715468/57dea1ea-d40d-11e6-93db-f034d7811cd7.jpg)

So I've created PR.

Thanks,
Oleksii